### PR TITLE
updated hover color for speaker-twitter-icon

### DIFF
--- a/2020/css/style.css
+++ b/2020/css/style.css
@@ -685,7 +685,7 @@ Speaker's ==========*/
 }
 
 .speaker-contacts > .contact:hover {
-	color: #ffffff;
+	color: #E95D4F;
 }
 
 /*--------------------


### PR DESCRIPTION
changed color for the hover-effect of the twitter-icon. specific color was picked from the hovered submit-button (which actually sets the color using opacity, but this could not be applied here without structural changes).